### PR TITLE
React 16 new context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ jobs:
         - dartanalyzer .
         - dartfmt --line-length=120 --dry-run --set-exit-if-changed .
         - pub run dependency_validator -i build_runner,build_test,build_web_compilers
-        - pub run test -p chrome
+        - pub run build_runner test --release -- -p chrome
         - pub run build_runner test -- -p chrome

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,18 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        # These are globs for the entrypoints you want to compile.
+        generate_for:
+          - test/**.browser_test.dart
+          - example/**.dart
+        options:
+          # List any dart2js specific args here, or omit it.
+          dart2js_args:
+            # Omit type checks TODO change to -O4 at some point (e.g., --trust-primitives)
+            - -O3
+            # Generate CSP-compliant code since it will be used most often in prod
+            - --csp
+            # Disable minification for easier test/example debugging
+            - --no-minify
+

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -155,7 +155,7 @@ main() {
       });
 
       group('componentDidUpdate receives the same value created in getSnapshotBeforeUpdate when snapshot is', () {
-        testSnapshotType(expectedSnapshot) {
+        void testSnapshotType(dynamic expectedSnapshot) {
           LifecycleTestHelper component = getDartComponent(
               render(components2.LifecycleTest({'getSnapshotBeforeUpdate': (_, __, ___) => expectedSnapshot})));
 

--- a/test/react_client/js_backed_map_test.dart
+++ b/test/react_client/js_backed_map_test.dart
@@ -2,37 +2,19 @@
 @JS()
 library react.js_backed_map_test.dart;
 
-import 'dart:async';
-import 'dart:html' as html;
-
 import 'package:js/js.dart';
 import 'package:react/src/react_client/js_backed_map.dart';
 import 'package:test/test.dart';
+
 import '../shared_type_tester.dart';
 
 main() {
   group('JsBackedMap', () {
     group('sets and retrieves values without JS interop interfering with them:', () {
-      // These tests test assignments to the JS backed map when the values
-      // - have a static type
-      // - do not have a static type
-      //
-      // These tests should have direct value reads/writes (and not access via
-      // helper methods) in order to:
-      // - simulate any inlining that might be done in dart2js
-      // - ensure there aren't any casts or type-checking wrappers in DDC that
-
-      JsBackedMap jsBackedMap;
-      JsBackedMap dynamicJsBackedMap;
-
-      testTypeValue(testValue) {
-        jsBackedMap = new JsBackedMap();
-        dynamicJsBackedMap = new JsBackedMap();
-
+      void testTypeValue(dynamic testValue) {
+        final jsBackedMap = new JsBackedMap();
         jsBackedMap['testValue'] = testValue;
         expect(jsBackedMap['testValue'], same(testValue));
-        dynamicJsBackedMap['testValue'] = testValue as dynamic;
-        expect(dynamicJsBackedMap['testValue'], same(testValue));
       }
 
       sharedTypeTests(testTypeValue);

--- a/test/react_context_test.dart
+++ b/test/react_context_test.dart
@@ -16,7 +16,7 @@ import 'shared_type_tester.dart';
 main() {
   setClientConfiguration();
 
-  testTypeValue(typeToTest) {
+  void testTypeValue(dynamic typeToTest) {
     var mountNode = new html.DivElement();
     var contextTypeRef;
     var consumerRef;

--- a/test/shared_type_tester.dart
+++ b/test/shared_type_tester.dart
@@ -8,10 +8,8 @@ import 'dart:html' as html;
 import 'package:js/js.dart';
 import 'package:test/test.dart';
 
-typedef void TestTypeValue<T>(T value);
-
 void sharedTypeTests(
-  TestTypeValue testTypeValue, {
+  void Function(dynamic value) testTypeValue, {
   bool skipNormalDartObjects: false,
   bool skipDartMaps: false,
   bool skipPrimitives: false,


### PR DESCRIPTION
Changes:
- 45ed03a Update build config for dart2js, use build_runner to run dart2js tests
- f9e786d Update typing, remove redundant `as dynamic` JsBackedMap case

Testing:
- Verify CI passes
- Verify examples still get compiled when served in release mode: `pbr serve -r example`
